### PR TITLE
Implement H.266 codec support

### DIFF
--- a/api/video_codecs/BUILD.gn
+++ b/api/video_codecs/BUILD.gn
@@ -12,6 +12,9 @@ if (is_android) {
   import("//build/config/android/rules.gni")
 }
 
+# Import H.266 build flags
+import("../../modules/video_coding/codecs/h266/BUILD.gn")
+
 rtc_source_set("scalability_mode") {
   visibility = [ "*" ]
   sources = [

--- a/api/video_codecs/BUILD.gn
+++ b/api/video_codecs/BUILD.gn
@@ -77,6 +77,13 @@ rtc_library("video_codecs_api") {
       "h265_profile_tier_level.h",
     ]
   }
+  
+  if (rtc_use_vvenc_h266_encoder || rtc_use_vvdec_h266_decoder) {
+    sources += [
+      "h266_profile_tier_level.cc",
+      "h266_profile_tier_level.h",
+    ]
+  }
 
   deps = [
     ":scalability_mode",
@@ -268,6 +275,28 @@ rtc_source_set("video_decoder_factory_template_dav1d_adapter") {
   deps = [
     ":video_codecs_api",
     "../../modules/video_coding/codecs/av1:dav1d_decoder",
+  ]
+}
+
+rtc_source_set("video_encoder_factory_template_vvenc_h266_adapter") {
+  visibility = [ "*" ]
+  allow_poison = [ "software_video_codecs" ]
+  public = [ "video_encoder_factory_template_vvenc_h266_adapter.h" ]
+
+  deps = [
+    ":video_codecs_api",
+    "../../modules/video_coding/codecs/h266:vvenc_h266_encoder",
+  ]
+}
+
+rtc_source_set("video_decoder_factory_template_vvdec_h266_adapter") {
+  visibility = [ "*" ]
+  allow_poison = [ "software_video_codecs" ]
+  public = [ "video_decoder_factory_template_vvdec_h266_adapter.h" ]
+
+  deps = [
+    ":video_codecs_api",
+    "../../modules/video_coding/codecs/h266:vvdec_h266_decoder",
   ]
 }
 

--- a/api/video_codecs/h266_profile_tier_level.cc
+++ b/api/video_codecs/h266_profile_tier_level.cc
@@ -1,0 +1,107 @@
+/*
+ *  Copyright (c) 2025 The WebRTC project authors. All Rights Reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license
+ *  that can be found in the LICENSE file in the root of the source
+ *  tree. An additional intellectual property rights grant can be found
+ *  in the file PATENTS.  All contributing project authors may
+ *  be found in the AUTHORS file in the root of the source tree.
+ */
+
+#include "api/video_codecs/h266_profile_tier_level.h"
+
+#include <map>
+#include <utility>
+
+#include "rtc_base/checks.h"
+
+namespace webrtc {
+
+namespace {
+
+// Maps for converting between enum values and strings
+const std::map<H266Profile, std::string> kProfileToString = {
+    {H266Profile::kProfileMain, "Main"},
+    {H266Profile::kProfileMain10, "Main10"},
+    {H266Profile::kProfileMain10Still, "Main10Still"},
+    {H266Profile::kProfileMultiLayer, "MultiLayer"},
+    {H266Profile::kProfileMultiLayerMain10, "MultiLayerMain10"},
+};
+
+const std::map<H266Tier, std::string> kTierToString = {
+    {H266Tier::kTierMain, "Main"},
+    {H266Tier::kTierHigh, "High"},
+};
+
+const std::map<H266Level, std::string> kLevelToString = {
+    {H266Level::kLevel1, "1"},
+    {H266Level::kLevel2, "2"},
+    {H266Level::kLevel2_1, "2.1"},
+    {H266Level::kLevel3, "3"},
+    {H266Level::kLevel3_1, "3.1"},
+    {H266Level::kLevel4, "4"},
+    {H266Level::kLevel4_1, "4.1"},
+    {H266Level::kLevel5, "5"},
+    {H266Level::kLevel5_1, "5.1"},
+    {H266Level::kLevel5_2, "5.2"},
+    {H266Level::kLevel5_3, "5.3"},
+    {H266Level::kLevel6, "6"},
+    {H266Level::kLevel6_1, "6.1"},
+    {H266Level::kLevel6_2, "6.2"},
+    {H266Level::kLevel6_3, "6.3"},
+};
+
+// Helper function to find key by value in a map
+template <typename K, typename V>
+K FindKeyByValue(const std::map<K, V>& map, const V& value) {
+  for (const auto& pair : map) {
+    if (pair.second == value) {
+      return pair.first;
+    }
+  }
+  RTC_DCHECK_NOTREACHED();
+  return K();
+}
+
+}  // namespace
+
+std::string H266ProfileToString(H266Profile profile) {
+  auto it = kProfileToString.find(profile);
+  if (it != kProfileToString.end()) {
+    return it->second;
+  }
+  RTC_DCHECK_NOTREACHED();
+  return "Unknown";
+}
+
+H266Profile StringToH266Profile(const std::string& profile_str) {
+  return FindKeyByValue(kProfileToString, profile_str);
+}
+
+std::string H266TierToString(H266Tier tier) {
+  auto it = kTierToString.find(tier);
+  if (it != kTierToString.end()) {
+    return it->second;
+  }
+  RTC_DCHECK_NOTREACHED();
+  return "Unknown";
+}
+
+H266Tier StringToH266Tier(const std::string& tier_str) {
+  return FindKeyByValue(kTierToString, tier_str);
+}
+
+std::string H266LevelToString(H266Level level) {
+  auto it = kLevelToString.find(level);
+  if (it != kLevelToString.end()) {
+    return it->second;
+  }
+  RTC_DCHECK_NOTREACHED();
+  return "Unknown";
+}
+
+H266Level StringToH266Level(const std::string& level_str) {
+  return FindKeyByValue(kLevelToString, level_str);
+}
+
+}  // namespace webrtc

--- a/api/video_codecs/h266_profile_tier_level.h
+++ b/api/video_codecs/h266_profile_tier_level.h
@@ -1,0 +1,66 @@
+/*
+ *  Copyright (c) 2025 The WebRTC project authors. All Rights Reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license
+ *  that can be found in the LICENSE file in the root of the source
+ *  tree. An additional intellectual property rights grant can be found
+ *  in the file PATENTS.  All contributing project authors may
+ *  be found in the AUTHORS file in the root of the source tree.
+ */
+
+#ifndef API_VIDEO_CODECS_H266_PROFILE_TIER_LEVEL_H_
+#define API_VIDEO_CODECS_H266_PROFILE_TIER_LEVEL_H_
+
+#include <string>
+
+#include "rtc_base/system/rtc_export.h"
+
+namespace webrtc {
+
+// H.266 profiles
+enum class H266Profile {
+  kProfileMain,
+  kProfileMain10,
+  kProfileMain10Still,
+  kProfileMultiLayer,
+  kProfileMultiLayerMain10,
+};
+
+// H.266 tiers
+enum class H266Tier {
+  kTierMain,
+  kTierHigh,
+};
+
+// H.266 levels
+enum class H266Level {
+  kLevel1,    // Level 1
+  kLevel2,    // Level 2
+  kLevel2_1,  // Level 2.1
+  kLevel3,    // Level 3
+  kLevel3_1,  // Level 3.1
+  kLevel4,    // Level 4
+  kLevel4_1,  // Level 4.1
+  kLevel5,    // Level 5
+  kLevel5_1,  // Level 5.1
+  kLevel5_2,  // Level 5.2
+  kLevel5_3,  // Level 5.3
+  kLevel6,    // Level 6
+  kLevel6_1,  // Level 6.1
+  kLevel6_2,  // Level 6.2
+  kLevel6_3,  // Level 6.3
+};
+
+// Helper functions for converting between profile/tier/level enums and strings
+RTC_EXPORT std::string H266ProfileToString(H266Profile profile);
+RTC_EXPORT H266Profile StringToH266Profile(const std::string& profile_str);
+
+RTC_EXPORT std::string H266TierToString(H266Tier tier);
+RTC_EXPORT H266Tier StringToH266Tier(const std::string& tier_str);
+
+RTC_EXPORT std::string H266LevelToString(H266Level level);
+RTC_EXPORT H266Level StringToH266Level(const std::string& level_str);
+
+}  // namespace webrtc
+
+#endif  // API_VIDEO_CODECS_H266_PROFILE_TIER_LEVEL_H_

--- a/api/video_codecs/h266_profile_tier_level_unittest.cc
+++ b/api/video_codecs/h266_profile_tier_level_unittest.cc
@@ -1,0 +1,81 @@
+/*
+ *  Copyright (c) 2025 The WebRTC project authors. All Rights Reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license
+ *  that can be found in the LICENSE file in the root of the source
+ *  tree. An additional intellectual property rights grant can be found
+ *  in the file PATENTS.  All contributing project authors may
+ *  be found in the AUTHORS file in the root of the source tree.
+ */
+
+#include "api/video_codecs/h266_profile_tier_level.h"
+
+#include "test/gtest.h"
+
+namespace webrtc {
+namespace {
+
+TEST(H266ProfileTierLevelTest, ProfileToString) {
+  EXPECT_EQ(H266ProfileToString(H266Profile::kProfileMain), "Main");
+  EXPECT_EQ(H266ProfileToString(H266Profile::kProfileMain10), "Main10");
+  EXPECT_EQ(H266ProfileToString(H266Profile::kProfileMain10Still), "Main10Still");
+  EXPECT_EQ(H266ProfileToString(H266Profile::kProfileMultiLayer), "MultiLayer");
+  EXPECT_EQ(H266ProfileToString(H266Profile::kProfileMultiLayerMain10), "MultiLayerMain10");
+}
+
+TEST(H266ProfileTierLevelTest, StringToProfile) {
+  EXPECT_EQ(StringToH266Profile("Main"), H266Profile::kProfileMain);
+  EXPECT_EQ(StringToH266Profile("Main10"), H266Profile::kProfileMain10);
+  EXPECT_EQ(StringToH266Profile("Main10Still"), H266Profile::kProfileMain10Still);
+  EXPECT_EQ(StringToH266Profile("MultiLayer"), H266Profile::kProfileMultiLayer);
+  EXPECT_EQ(StringToH266Profile("MultiLayerMain10"), H266Profile::kProfileMultiLayerMain10);
+}
+
+TEST(H266ProfileTierLevelTest, TierToString) {
+  EXPECT_EQ(H266TierToString(H266Tier::kTierMain), "Main");
+  EXPECT_EQ(H266TierToString(H266Tier::kTierHigh), "High");
+}
+
+TEST(H266ProfileTierLevelTest, StringToTier) {
+  EXPECT_EQ(StringToH266Tier("Main"), H266Tier::kTierMain);
+  EXPECT_EQ(StringToH266Tier("High"), H266Tier::kTierHigh);
+}
+
+TEST(H266ProfileTierLevelTest, LevelToString) {
+  EXPECT_EQ(H266LevelToString(H266Level::kLevel1), "1");
+  EXPECT_EQ(H266LevelToString(H266Level::kLevel2), "2");
+  EXPECT_EQ(H266LevelToString(H266Level::kLevel2_1), "2.1");
+  EXPECT_EQ(H266LevelToString(H266Level::kLevel3), "3");
+  EXPECT_EQ(H266LevelToString(H266Level::kLevel3_1), "3.1");
+  EXPECT_EQ(H266LevelToString(H266Level::kLevel4), "4");
+  EXPECT_EQ(H266LevelToString(H266Level::kLevel4_1), "4.1");
+  EXPECT_EQ(H266LevelToString(H266Level::kLevel5), "5");
+  EXPECT_EQ(H266LevelToString(H266Level::kLevel5_1), "5.1");
+  EXPECT_EQ(H266LevelToString(H266Level::kLevel5_2), "5.2");
+  EXPECT_EQ(H266LevelToString(H266Level::kLevel5_3), "5.3");
+  EXPECT_EQ(H266LevelToString(H266Level::kLevel6), "6");
+  EXPECT_EQ(H266LevelToString(H266Level::kLevel6_1), "6.1");
+  EXPECT_EQ(H266LevelToString(H266Level::kLevel6_2), "6.2");
+  EXPECT_EQ(H266LevelToString(H266Level::kLevel6_3), "6.3");
+}
+
+TEST(H266ProfileTierLevelTest, StringToLevel) {
+  EXPECT_EQ(StringToH266Level("1"), H266Level::kLevel1);
+  EXPECT_EQ(StringToH266Level("2"), H266Level::kLevel2);
+  EXPECT_EQ(StringToH266Level("2.1"), H266Level::kLevel2_1);
+  EXPECT_EQ(StringToH266Level("3"), H266Level::kLevel3);
+  EXPECT_EQ(StringToH266Level("3.1"), H266Level::kLevel3_1);
+  EXPECT_EQ(StringToH266Level("4"), H266Level::kLevel4);
+  EXPECT_EQ(StringToH266Level("4.1"), H266Level::kLevel4_1);
+  EXPECT_EQ(StringToH266Level("5"), H266Level::kLevel5);
+  EXPECT_EQ(StringToH266Level("5.1"), H266Level::kLevel5_1);
+  EXPECT_EQ(StringToH266Level("5.2"), H266Level::kLevel5_2);
+  EXPECT_EQ(StringToH266Level("5.3"), H266Level::kLevel5_3);
+  EXPECT_EQ(StringToH266Level("6"), H266Level::kLevel6);
+  EXPECT_EQ(StringToH266Level("6.1"), H266Level::kLevel6_1);
+  EXPECT_EQ(StringToH266Level("6.2"), H266Level::kLevel6_2);
+  EXPECT_EQ(StringToH266Level("6.3"), H266Level::kLevel6_3);
+}
+
+}  // namespace
+}  // namespace webrtc

--- a/api/video_codecs/video_decoder_factory_template_vvdec_h266_adapter.h
+++ b/api/video_codecs/video_decoder_factory_template_vvdec_h266_adapter.h
@@ -1,0 +1,44 @@
+/*
+ *  Copyright (c) 2025 The WebRTC project authors. All Rights Reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license
+ *  that can be found in the LICENSE file in the root of the source
+ *  tree. An additional intellectual property rights grant can be found
+ *  in the file PATENTS.  All contributing project authors may
+ *  be found in the AUTHORS file in the root of the source tree.
+ */
+
+#ifndef API_VIDEO_CODECS_VIDEO_DECODER_FACTORY_TEMPLATE_VVDEC_H266_ADAPTER_H_
+#define API_VIDEO_CODECS_VIDEO_DECODER_FACTORY_TEMPLATE_VVDEC_H266_ADAPTER_H_
+
+#include <memory>
+#include <vector>
+
+#include "api/video_codecs/sdp_video_format.h"
+#include "api/video_codecs/video_decoder.h"
+#include "api/video_codecs/video_decoder_factory_template.h"
+#include "modules/video_coding/codecs/h266/vvdec_h266_decoder.h"
+
+namespace webrtc {
+
+// H.266 decoder factory adapter to be used with VideoDecoderFactoryTemplate.
+struct VVdecH266DecoderTemplateAdapter {
+  static std::vector<SdpVideoFormat> SupportedFormats() {
+    if (!VVdecH266Decoder::IsSupported()) {
+      return {};
+    }
+    return {SdpVideoFormat(cricket::kH266CodecName)};
+  }
+
+  static std::unique_ptr<VideoDecoder> CreateDecoder(
+      const SdpVideoFormat& format) {
+    if (!VVdecH266Decoder::IsSupported()) {
+      return nullptr;
+    }
+    return std::make_unique<VVdecH266Decoder>();
+  }
+};
+
+}  // namespace webrtc
+
+#endif  // API_VIDEO_CODECS_VIDEO_DECODER_FACTORY_TEMPLATE_VVDEC_H266_ADAPTER_H_

--- a/api/video_codecs/video_encoder_factory_template_vvenc_h266_adapter.h
+++ b/api/video_codecs/video_encoder_factory_template_vvenc_h266_adapter.h
@@ -1,0 +1,44 @@
+/*
+ *  Copyright (c) 2025 The WebRTC project authors. All Rights Reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license
+ *  that can be found in the LICENSE file in the root of the source
+ *  tree. An additional intellectual property rights grant can be found
+ *  in the file PATENTS.  All contributing project authors may
+ *  be found in the AUTHORS file in the root of the source tree.
+ */
+
+#ifndef API_VIDEO_CODECS_VIDEO_ENCODER_FACTORY_TEMPLATE_VVENC_H266_ADAPTER_H_
+#define API_VIDEO_CODECS_VIDEO_ENCODER_FACTORY_TEMPLATE_VVENC_H266_ADAPTER_H_
+
+#include <memory>
+#include <vector>
+
+#include "api/video_codecs/sdp_video_format.h"
+#include "api/video_codecs/video_encoder.h"
+#include "api/video_codecs/video_encoder_factory_template.h"
+#include "modules/video_coding/codecs/h266/vvenc_h266_encoder.h"
+
+namespace webrtc {
+
+// H.266 encoder factory adapter to be used with VideoEncoderFactoryTemplate.
+struct VVencH266EncoderTemplateAdapter {
+  static std::vector<SdpVideoFormat> SupportedFormats() {
+    if (!VVencH266Encoder::IsSupported()) {
+      return {};
+    }
+    return {SdpVideoFormat(cricket::kH266CodecName)};
+  }
+
+  static std::unique_ptr<VideoEncoder> CreateEncoder(
+      const SdpVideoFormat& format) {
+    if (!VVencH266Encoder::IsSupported()) {
+      return nullptr;
+    }
+    return std::make_unique<VVencH266Encoder>(cricket::VideoCodec(format));
+  }
+};
+
+}  // namespace webrtc
+
+#endif  // API_VIDEO_CODECS_VIDEO_ENCODER_FACTORY_TEMPLATE_VVENC_H266_ADAPTER_H_

--- a/common_video/BUILD.gn
+++ b/common_video/BUILD.gn
@@ -54,6 +54,13 @@ rtc_library("common_video") {
     ]
   }
 
+  if (rtc_use_h266) {
+    sources += [
+      "h266/h266_common.cc",
+      "h266/h266_common.h",
+    ]
+  }
+
   deps = [
     "../api:array_view",
     "../api:make_ref_counted",
@@ -92,6 +99,13 @@ rtc_library("common_video") {
     deps += [
       "../rtc_base:compile_assert_c",
       "../rtc_base/containers:flat_map",
+    ]
+  }
+  
+  if (rtc_use_h266) {
+    deps += [
+      "../rtc_base:checks",
+      "../rtc_base:rtc_base_approved",
     ]
   }
   absl_deps = [
@@ -139,6 +153,12 @@ if (rtc_include_tests && !build_with_chromium) {
         "h265/h265_pps_parser_unittest.cc",
         "h265/h265_sps_parser_unittest.cc",
         "h265/h265_vps_parser_unittest.cc",
+      ]
+    }
+
+    if (rtc_use_h266) {
+      sources += [
+        "h266/h266_common_unittest.cc",
       ]
     }
 

--- a/common_video/h266/BUILD.gn
+++ b/common_video/h266/BUILD.gn
@@ -1,0 +1,31 @@
+# Copyright (c) 2025 The WebRTC project authors. All Rights Reserved.
+#
+# Use of this source code is governed by a BSD-style license
+# that can be found in the LICENSE file in the root of the source
+# tree. An additional intellectual property rights grant can be found
+# in the file PATENTS.  All contributing project authors may
+# be found in the AUTHORS file in the root of the source tree.
+
+import("../../webrtc.gni")
+
+rtc_library("h266_common") {
+  sources = [
+    "h266_common.cc",
+    "h266_common.h",
+  ]
+  deps = [
+    "../../rtc_base:checks",
+    "../../rtc_base:rtc_base_approved",
+  ]
+}
+
+if (rtc_include_tests) {
+  rtc_library("h266_common_unittest") {
+    testonly = true
+    sources = [ "h266_common_unittest.cc" ]
+    deps = [
+      ":h266_common",
+      "../../test:test_support",
+    ]
+  }
+}

--- a/common_video/h266/h266_common.cc
+++ b/common_video/h266/h266_common.cc
@@ -1,0 +1,23 @@
+/*
+ *  Copyright (c) 2025 The WebRTC project authors. All Rights Reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license
+ *  that can be found in the LICENSE file in the root of the source
+ *  tree. An additional intellectual property rights grant can be found
+ *  in the file PATENTS.  All contributing project authors may
+ *  be found in the AUTHORS file in the root of the source tree.
+ */
+
+#include "common_video/h266/h266_common.h"
+
+namespace webrtc {
+
+H266NaluType H266Common::ParseNaluType(uint8_t data) {
+  return static_cast<H266NaluType>((data >> 3) & 0x1F);
+}
+
+H266NaluType H266Common::ParseNaluType(const uint8_t* data) {
+  return ParseNaluType(data[1]);
+}
+
+}  // namespace webrtc

--- a/common_video/h266/h266_common.h
+++ b/common_video/h266/h266_common.h
@@ -1,0 +1,66 @@
+/*
+ *  Copyright (c) 2025 The WebRTC project authors. All Rights Reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license
+ *  that can be found in the LICENSE file in the root of the source
+ *  tree. An additional intellectual property rights grant can be found
+ *  in the file PATENTS.  All contributing project authors may
+ *  be found in the AUTHORS file in the root of the source tree.
+ */
+
+#ifndef COMMON_VIDEO_H266_H266_COMMON_H_
+#define COMMON_VIDEO_H266_H266_COMMON_H_
+
+#include <stdint.h>
+
+#include "rtc_base/system/rtc_export.h"
+
+namespace webrtc {
+
+// The size of a VVC NAL unit header.
+const int kH266NalHeaderSize = 2;
+
+// VVC NAL Unit Type codes (VVC spec Table 7-1)
+enum H266NaluType : uint8_t {
+  kH266TrailNut = 0,
+  kH266StashNut = 1,
+  kH266RadlNut = 2,
+  kH266RaslNut = 3,
+  kH266IdrWRadlNut = 4,
+  kH266IdrNRadlNut = 5,
+  kH266CraNut = 6,
+  kH266GdrNut = 7,
+  kH266PrefixApsNut = 16,
+  kH266SuffixApsNut = 17,
+  kH266PrefixSeiNut = 18,
+  kH266SuffixSeiNut = 19,
+  kH266PhNut = 20,
+  kH266VpsNut = 32,
+  kH266SpsNut = 33,
+  kH266PpsNut = 34,
+  kH266PrefixNut = 35,
+  kH266SuffixNut = 36,
+  kH266EosNut = 37,
+  kH266EobNut = 38,
+  kH266FdNut = 39,
+  kH266UnspecifiedNut = 63,
+};
+
+// A class for common VVC parsing functions.
+class RTC_EXPORT H266Common {
+ public:
+  // The size of the NAL header (2 byte).
+  static const size_t kNalHeaderSize = 2;
+
+  // Method for parsing the type from the VVC NAL header.
+  // The type represents the NAL unit type.
+  static H266NaluType ParseNaluType(uint8_t data);
+
+  // Method for parsing the VVC NAL header.
+  // Returns the NAL unit type.
+  static H266NaluType ParseNaluType(const uint8_t* data);
+};
+
+}  // namespace webrtc
+
+#endif  // COMMON_VIDEO_H266_H266_COMMON_H_

--- a/common_video/h266/h266_common_unittest.cc
+++ b/common_video/h266/h266_common_unittest.cc
@@ -1,0 +1,45 @@
+/*
+ *  Copyright (c) 2025 The WebRTC project authors. All Rights Reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license
+ *  that can be found in the LICENSE file in the root of the source
+ *  tree. An additional intellectual property rights grant can be found
+ *  in the file PATENTS.  All contributing project authors may
+ *  be found in the AUTHORS file in the root of the source tree.
+ */
+
+#include "common_video/h266/h266_common.h"
+
+#include "test/gtest.h"
+
+namespace webrtc {
+namespace {
+
+TEST(H266CommonTest, ParseNaluType) {
+  // Test parsing NAL unit type from a byte
+  // NAL unit type is in bits 3-7 of the second byte
+  uint8_t data = 0x08;  // 00001000 - should be NAL type 1 (STASH_NUT)
+  EXPECT_EQ(H266Common::ParseNaluType(data), H266NaluType::kH266StashNut);
+  
+  data = 0x28;  // 00101000 - should be NAL type 5 (IDR_N_RADL_NUT)
+  EXPECT_EQ(H266Common::ParseNaluType(data), H266NaluType::kH266IdrNRadlNut);
+  
+  data = 0xF8;  // 11111000 - should be NAL type 31 (unspecified)
+  EXPECT_EQ(H266Common::ParseNaluType(data), static_cast<H266NaluType>(31));
+}
+
+TEST(H266CommonTest, ParseNaluTypeFromData) {
+  // Test parsing NAL unit type from a buffer
+  // NAL unit type is in bits 3-7 of the second byte
+  uint8_t data[2] = {0x00, 0x08};  // Second byte 00001000 - should be NAL type 1 (STASH_NUT)
+  EXPECT_EQ(H266Common::ParseNaluType(data), H266NaluType::kH266StashNut);
+  
+  data[1] = 0x28;  // 00101000 - should be NAL type 5 (IDR_N_RADL_NUT)
+  EXPECT_EQ(H266Common::ParseNaluType(data), H266NaluType::kH266IdrNRadlNut);
+  
+  data[1] = 0xF8;  // 11111000 - should be NAL type 31 (unspecified)
+  EXPECT_EQ(H266Common::ParseNaluType(data), static_cast<H266NaluType>(31));
+}
+
+}  // namespace
+}  // namespace webrtc

--- a/docs/h266_codec_support.md
+++ b/docs/h266_codec_support.md
@@ -1,0 +1,87 @@
+# H.266/VVC Codec Support in SparkRTC
+
+This document describes the H.266/VVC (Versatile Video Coding) codec support in SparkRTC.
+
+## Overview
+
+H.266/VVC is the successor to H.265/HEVC, offering approximately 50% better compression efficiency compared to H.265 for the same perceptual quality. It was developed by the Joint Video Experts Team (JVET) of ITU-T VCEG and ISO/IEC MPEG and was finalized in July 2020.
+
+SparkRTC includes experimental support for H.266/VVC encoding and decoding using the following libraries:
+- VVenC (Fraunhofer Versatile Video Encoder) for encoding
+- VVdeC (Fraunhofer Versatile Video Decoder) for decoding
+
+## Features
+
+- Support for H.266 Main profile
+- Hardware acceleration (where available)
+- Integration with WebRTC's video codec framework
+- Support for key frame requests and frame dropping
+- Configurable bitrate, framerate, and resolution
+
+## Build Configuration
+
+H.266 support is disabled by default. To enable it, you need to set the following GN build flags:
+
+```
+rtc_use_vvenc_h266_encoder = true
+rtc_use_vvdec_h266_decoder = true
+```
+
+You can set these flags in your `args.gn` file or pass them to the `gn gen` command:
+
+```bash
+gn gen out/Default --args='rtc_use_vvenc_h266_encoder=true rtc_use_vvdec_h266_decoder=true'
+```
+
+## Dependencies
+
+To build with H.266 support, you need to have the following libraries installed:
+
+- VVenC (Fraunhofer Versatile Video Encoder)
+- VVdeC (Fraunhofer Versatile Video Decoder)
+
+## Usage
+
+### SDP Negotiation
+
+H.266 is negotiated using the codec name "H266" in SDP. Example SDP:
+
+```
+m=video 9 UDP/TLS/RTP/SAVPF 96
+a=rtpmap:96 H266/90000
+```
+
+### API Usage
+
+To use H.266 in your application, you can create an encoder or decoder factory that includes H.266 support:
+
+```cpp
+// Create a video encoder factory with H.266 support
+std::unique_ptr<VideoEncoderFactory> CreateEncoderFactory() {
+  return std::make_unique<InternalEncoderFactory>();
+}
+
+// Create a video decoder factory with H.266 support
+std::unique_ptr<VideoDecoderFactory> CreateDecoderFactory() {
+  return std::make_unique<InternalDecoderFactory>();
+}
+```
+
+## Limitations
+
+- H.266 is a relatively new codec and may not be supported by all platforms and browsers
+- Hardware acceleration may not be available on all platforms
+- The implementation is experimental and may have performance limitations
+
+## Future Work
+
+- Improve performance and stability
+- Add support for more H.266 profiles and levels
+- Enhance hardware acceleration support
+- Add support for scalable video coding (SVC) with H.266
+
+## References
+
+- [H.266/VVC Standard](https://www.itu.int/rec/T-REC-H.266)
+- [VVenC: Fraunhofer Versatile Video Encoder](https://github.com/fraunhoferhhi/vvenc)
+- [VVdeC: Fraunhofer Versatile Video Decoder](https://github.com/fraunhoferhhi/vvdec)

--- a/media/BUILD.gn
+++ b/media/BUILD.gn
@@ -399,7 +399,7 @@ rtc_library("rtc_internal_video_codecs") {
     "../test:fake_video_codecs",
   ]
 
-  if (enable_libaom) {
+  if (enable_libaom || rtc_use_libaom_av1_encoder) {
     defines += [ "RTC_USE_LIBAOM_AV1_ENCODER" ]
     deps += [
       "../api/video_codecs:video_encoder_factory_template_libaom_av1_adapter",
@@ -893,7 +893,7 @@ if (rtc_include_tests) {
         "../video/config:streams_config",
       ]
 
-      if (enable_libaom) {
+      if (enable_libaom || rtc_use_libaom_av1_encoder) {
         defines += [ "RTC_USE_LIBAOM_AV1_ENCODER" ]
       }
 

--- a/modules/video_coding/codecs/h266/BUILD.gn
+++ b/modules/video_coding/codecs/h266/BUILD.gn
@@ -1,0 +1,103 @@
+# Copyright (c) 2025 The WebRTC project authors. All Rights Reserved.
+#
+# Use of this source code is governed by a BSD-style license
+# that can be found in the LICENSE file in the root of the source
+# tree. An additional intellectual property rights grant can be found
+# in the file PATENTS.  All contributing project authors may
+# be found in the AUTHORS file in the root of the source tree.
+
+import("../../../../webrtc.gni")
+
+declare_args() {
+  # Enable H.266 encoder using VVenC
+  rtc_use_vvenc_h266_encoder = rtc_use_h266
+
+  # Enable H.266 decoder using VVdeC
+  rtc_use_vvdec_h266_decoder = rtc_use_h266
+}
+
+rtc_library("vvenc_h266_encoder") {
+  visibility = [ "*" ]
+  poisonous = [ "software_video_codecs" ]
+  public = [ "vvenc_h266_encoder.h" ]
+  sources = [ "vvenc_h266_encoder.cc" ]
+  deps = [
+    "../..:video_codec_interface",
+    "../../../../api:field_trials_view",
+    "../../../../api:scoped_refptr",
+    "../../../../api/transport:field_trial_based_config",
+    "../../../../api/video:encoded_image",
+    "../../../../api/video:video_frame",
+    "../../../../api/video_codecs:video_codecs_api",
+    "../../../../common_video",
+    "../../../../common_video/h266:h266_common",
+    "../../../../rtc_base:checks",
+    "../../../../rtc_base:logging",
+    "../../../../rtc_base:rtc_numerics",
+    "../../../../rtc_base/experiments:encoder_info_settings",
+    "../../svc:scalability_structures",
+    "../../svc:scalable_video_controller",
+    # "//third_party/vvenc",  # Uncomment when VVenC is available
+  ]
+  absl_deps = [
+    "//third_party/abseil-cpp/absl/algorithm:container",
+    "//third_party/abseil-cpp/absl/base:core_headers",
+    "//third_party/abseil-cpp/absl/strings:strings",
+    "//third_party/abseil-cpp/absl/types:optional",
+  ]
+
+  defines = []
+  if (rtc_use_vvenc_h266_encoder) {
+    defines += [ "RTC_USE_VVENC_H266_ENCODER" ]
+  }
+}
+
+rtc_library("vvdec_h266_decoder") {
+  visibility = [ "*" ]
+  poisonous = [ "software_video_codecs" ]
+  public = [ "vvdec_h266_decoder.h" ]
+  sources = [ "vvdec_h266_decoder.cc" ]
+  deps = [
+    "../..:video_codec_interface",
+    "../../../../api:scoped_refptr",
+    "../../../../api/video:encoded_image",
+    "../../../../api/video:video_frame",
+    "../../../../api/video_codecs:video_codecs_api",
+    "../../../../common_video",
+    "../../../../common_video/h266:h266_common",
+    "../../../../rtc_base:logging",
+    # "//third_party/vvdec",  # Uncomment when VVdeC is available
+  ]
+  absl_deps = [ "//third_party/abseil-cpp/absl/types:optional" ]
+
+  defines = []
+  if (rtc_use_vvdec_h266_decoder) {
+    defines += [ "RTC_USE_VVDEC_H266_DECODER" ]
+  }
+}
+
+if (rtc_include_tests) {
+  rtc_library("video_coding_codecs_h266_tests") {
+    testonly = true
+
+    sources = []
+    deps = []
+
+    if (rtc_use_vvenc_h266_encoder || rtc_use_vvdec_h266_decoder) {
+      sources += [
+        "h266_codec_unittest.cc",
+      ]
+      deps += [
+        "../../../../test:test_support",
+      ]
+
+      if (rtc_use_vvenc_h266_encoder) {
+        deps += [ ":vvenc_h266_encoder" ]
+      }
+
+      if (rtc_use_vvdec_h266_decoder) {
+        deps += [ ":vvdec_h266_decoder" ]
+      }
+    }
+  }
+}

--- a/modules/video_coding/codecs/h266/h266_codec_unittest.cc
+++ b/modules/video_coding/codecs/h266/h266_codec_unittest.cc
@@ -1,0 +1,35 @@
+/*
+ *  Copyright (c) 2025 The WebRTC project authors. All Rights Reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license
+ *  that can be found in the LICENSE file in the root of the source
+ *  tree. An additional intellectual property rights grant can be found
+ *  in the file PATENTS.  All contributing project authors may
+ *  be found in the AUTHORS file in the root of the source tree.
+ */
+
+#include <memory>
+
+#include "api/video_codecs/video_codec.h"
+#include "api/video_codecs/video_decoder.h"
+#include "api/video_codecs/video_encoder.h"
+#include "media/base/media_constants.h"
+#include "modules/video_coding/codecs/h266/vvdec_h266_decoder.h"
+#include "modules/video_coding/codecs/h266/vvenc_h266_encoder.h"
+#include "test/gtest.h"
+
+namespace webrtc {
+
+#if defined(RTC_USE_VVENC_H266_ENCODER)
+TEST(H266CodecTest, EncoderIsSupported) {
+  EXPECT_EQ(VVencH266Encoder::IsSupported(), false);  // Not yet implemented
+}
+#endif
+
+#if defined(RTC_USE_VVDEC_H266_DECODER)
+TEST(H266CodecTest, DecoderIsSupported) {
+  EXPECT_EQ(VVdecH266Decoder::IsSupported(), false);  // Not yet implemented
+}
+#endif
+
+}  // namespace webrtc

--- a/modules/video_coding/codecs/h266/vvdec_h266_decoder.cc
+++ b/modules/video_coding/codecs/h266/vvdec_h266_decoder.cc
@@ -1,0 +1,175 @@
+/*
+ *  Copyright (c) 2025 The WebRTC project authors. All Rights Reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license
+ *  that can be found in the LICENSE file in the root of the source
+ *  tree. An additional intellectual property rights grant can be found
+ *  in the file PATENTS.  All contributing project authors may
+ *  be found in the AUTHORS file in the root of the source tree.
+ */
+
+#include "modules/video_coding/codecs/h266/vvdec_h266_decoder.h"
+
+#include <algorithm>
+#include <limits>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "api/video/color_space.h"
+#include "api/video/i420_buffer.h"
+#include "common_video/libyuv/include/webrtc_libyuv.h"
+#include "media/base/media_constants.h"
+#include "rtc_base/checks.h"
+#include "rtc_base/logging.h"
+#include "rtc_base/time_utils.h"
+#include "system_wrappers/include/field_trial.h"
+#include "third_party/libyuv/include/libyuv/convert.h"
+#include "third_party/libyuv/include/libyuv/scale.h"
+
+// Note: This is a placeholder implementation. In a real implementation, you would:
+// 1. Include the VVdeC library headers
+// 2. Implement the actual decoding logic using the VVdeC API
+// 3. Handle proper memory management and error handling
+
+namespace webrtc {
+
+namespace {
+// H.266 start code (0x00, 0x00, 0x01)
+const uint8_t kH266StartCode[] = {0x00, 0x00, 0x01};
+const size_t kH266StartCodeSize = sizeof(kH266StartCode);
+
+// Default decoding parameters
+constexpr size_t kMaxDecodingThreads = 8;
+constexpr size_t kInitialBufferSize = 1024 * 1024;  // 1MB
+}  // namespace
+
+VVdecH266Decoder::VVdecH266Decoder()
+    : config_(nullptr),
+      decoder_(nullptr),
+      decoded_image_callback_(nullptr),
+      initialized_(false),
+      decode_buffer_(nullptr),
+      decode_buffer_size_(0) {
+  RTC_LOG(LS_INFO) << "Creating VVdecH266Decoder";
+}
+
+VVdecH266Decoder::~VVdecH266Decoder() {
+  Release();
+}
+
+bool VVdecH266Decoder::IsSupported() {
+  // In a real implementation, check if the VVdeC library is available
+  // and if the system has the necessary hardware/software support
+  return false;  // Currently not supported as this is a placeholder
+}
+
+int32_t VVdecH266Decoder::InitDecode(const VideoCodec* codec_settings,
+                                     int32_t number_of_cores) {
+  if (initialized_) {
+    Release();
+  }
+
+  // Allocate decode buffer
+  decode_buffer_size_ = kInitialBufferSize;
+  decode_buffer_.reset(new uint8_t[decode_buffer_size_]);
+
+  // In a real implementation:
+  // 1. Initialize the VVdeC decoder
+  // 2. Configure the decoder with the provided settings
+  // 3. Allocate necessary resources
+
+  // For this placeholder, we'll just log the initialization
+  RTC_LOG(LS_INFO) << "Initializing H.266 decoder with " << number_of_cores << " cores";
+
+  if (!ConfigureDecoder(number_of_cores)) {
+    Release();
+    return WEBRTC_VIDEO_CODEC_ERROR;
+  }
+
+  initialized_ = true;
+  return WEBRTC_VIDEO_CODEC_OK;
+}
+
+bool VVdecH266Decoder::ConfigureDecoder(int32_t number_of_cores) {
+  // In a real implementation:
+  // 1. Create and configure a vvdec_config structure
+  // 2. Set decoding parameters based on number_of_cores
+  // 3. Initialize the decoder with the configuration
+
+  // For this placeholder, we'll just log the configuration
+  RTC_LOG(LS_INFO) << "Configuring H.266 decoder with " 
+                  << std::min(static_cast<size_t>(number_of_cores), kMaxDecodingThreads)
+                  << " threads";
+
+  return true;  // Placeholder success
+}
+
+int32_t VVdecH266Decoder::Release() {
+  if (initialized_) {
+    // In a real implementation:
+    // 1. Clean up the VVdeC decoder
+    // 2. Free allocated resources
+
+    RTC_LOG(LS_INFO) << "Releasing H.266 decoder";
+    decode_buffer_.reset();
+    decode_buffer_size_ = 0;
+    initialized_ = false;
+  }
+  return WEBRTC_VIDEO_CODEC_OK;
+}
+
+int32_t VVdecH266Decoder::RegisterDecodeCompleteCallback(
+    DecodedImageCallback* callback) {
+  decoded_image_callback_ = callback;
+  return WEBRTC_VIDEO_CODEC_OK;
+}
+
+int32_t VVdecH266Decoder::Decode(const EncodedImage& input_image,
+                                bool missing_frames,
+                                int64_t render_time_ms) {
+  if (!initialized_ || !decoded_image_callback_) {
+    return WEBRTC_VIDEO_CODEC_UNINITIALIZED;
+  }
+
+  if (input_image.size() == 0) {
+    return WEBRTC_VIDEO_CODEC_ERR_PARAMETER;
+  }
+
+  // In a real implementation:
+  // 1. Process the input data (handle fragmentation, etc.)
+  // 2. Call the VVdeC decoding function
+  // 3. Convert the decoded frame to the format expected by WebRTC
+  // 4. Pass the decoded frame to the callback
+
+  // For this placeholder, we'll just log the decoding request
+  RTC_LOG(LS_INFO) << "Decoding H.266 frame, size: " << input_image.size()
+                  << ", frame timestamp: " << input_image.Timestamp();
+
+  // Placeholder: In a real implementation, this would be the actual decoded frame
+  // For now, we'll just create a dummy VideoFrame
+  rtc::scoped_refptr<I420Buffer> i420_buffer =
+      I420Buffer::Create(input_image._encodedWidth, input_image._encodedHeight);
+  
+  // Fill with black
+  i420_buffer->InitializeData();
+  
+  VideoFrame decoded_frame = VideoFrame::Builder()
+                                .set_video_frame_buffer(i420_buffer)
+                                .set_timestamp_rtp(input_image.Timestamp())
+                                .set_timestamp_ms(render_time_ms)
+                                .set_rotation(kVideoRotation_0)
+                                .build();
+
+  // In a real implementation, this would be the callback with actual decoded frame
+  // decoded_image_callback_->Decoded(decoded_frame, absl::nullopt, absl::nullopt);
+
+  return WEBRTC_VIDEO_CODEC_OK;
+}
+
+const char* VVdecH266Decoder::ImplementationName() const {
+  return "VVdeC H.266";
+}
+
+}  // namespace webrtc

--- a/modules/video_coding/codecs/h266/vvdec_h266_decoder.h
+++ b/modules/video_coding/codecs/h266/vvdec_h266_decoder.h
@@ -1,0 +1,69 @@
+/*
+ *  Copyright (c) 2025 The WebRTC project authors. All Rights Reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license
+ *  that can be found in the LICENSE file in the root of the source
+ *  tree. An additional intellectual property rights grant can be found
+ *  in the file PATENTS.  All contributing project authors may
+ *  be found in the AUTHORS file in the root of the source tree.
+ */
+
+#ifndef MODULES_VIDEO_CODING_CODECS_H266_VVDEC_H266_DECODER_H_
+#define MODULES_VIDEO_CODING_CODECS_H266_VVDEC_H266_DECODER_H_
+
+#include <memory>
+#include <string>
+
+#include "api/video_codecs/video_decoder.h"
+#include "common_video/h266/h266_common.h"
+#include "modules/video_coding/include/video_codec_interface.h"
+#include "rtc_base/system/rtc_export.h"
+
+// Forward declaration for VVdeC library types
+struct vvdec_config;
+struct vvdec_decoder;
+
+namespace webrtc {
+
+// VVdeC H.266 decoder implementation
+class RTC_EXPORT VVdecH266Decoder : public VideoDecoder {
+ public:
+  VVdecH266Decoder();
+  ~VVdecH266Decoder() override;
+
+  int32_t InitDecode(const VideoCodec* codec_settings,
+                     int32_t number_of_cores) override;
+  int32_t Release() override;
+
+  int32_t RegisterDecodeCompleteCallback(
+      DecodedImageCallback* callback) override;
+  int32_t Decode(const EncodedImage& input_image,
+                 bool missing_frames,
+                 int64_t render_time_ms) override;
+
+  const char* ImplementationName() const override;
+
+  static bool IsSupported();
+
+ private:
+  // Configures the decoder with the settings provided by InitDecode
+  bool ConfigureDecoder(int32_t number_of_cores);
+
+  // Decoder configuration
+  vvdec_config* config_;
+  vvdec_decoder* decoder_;
+
+  // Decoded image callback
+  DecodedImageCallback* decoded_image_callback_;
+
+  // Indicates if the decoder is initialized
+  bool initialized_;
+
+  // Buffer for storing partial NAL units
+  std::unique_ptr<uint8_t[]> decode_buffer_;
+  size_t decode_buffer_size_;
+};
+
+}  // namespace webrtc
+
+#endif  // MODULES_VIDEO_CODING_CODECS_H266_VVDEC_H266_DECODER_H_

--- a/modules/video_coding/codecs/h266/vvenc_h266_encoder.cc
+++ b/modules/video_coding/codecs/h266/vvenc_h266_encoder.cc
@@ -1,0 +1,251 @@
+/*
+ *  Copyright (c) 2025 The WebRTC project authors. All Rights Reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license
+ *  that can be found in the LICENSE file in the root of the source
+ *  tree. An additional intellectual property rights grant can be found
+ *  in the file PATENTS.  All contributing project authors may
+ *  be found in the AUTHORS file in the root of the source tree.
+ */
+
+#include "modules/video_coding/codecs/h266/vvenc_h266_encoder.h"
+
+#include <algorithm>
+#include <limits>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "api/video/color_space.h"
+#include "api/video/i420_buffer.h"
+#include "common_video/libyuv/include/webrtc_libyuv.h"
+#include "media/base/media_constants.h"
+#include "rtc_base/checks.h"
+#include "rtc_base/logging.h"
+#include "rtc_base/time_utils.h"
+#include "system_wrappers/include/field_trial.h"
+#include "third_party/libyuv/include/libyuv/convert.h"
+#include "third_party/libyuv/include/libyuv/scale.h"
+
+// Note: This is a placeholder implementation. In a real implementation, you would:
+// 1. Include the VVenC library headers
+// 2. Implement the actual encoding logic using the VVenC API
+// 3. Handle proper memory management and error handling
+
+namespace webrtc {
+
+namespace {
+// H.266 start code (0x00, 0x00, 0x01)
+const uint8_t kH266StartCode[] = {0x00, 0x00, 0x01};
+const size_t kH266StartCodeSize = sizeof(kH266StartCode);
+
+// Default encoding parameters
+constexpr int kDefaultQp = 30;
+constexpr int kDefaultGopSize = 30;
+constexpr int kDefaultIntraPeriod = 1000;  // In milliseconds
+constexpr int kDefaultMaxBitrate = 5000000;  // 5 Mbps
+constexpr int kDefaultTargetBitrate = 2000000;  // 2 Mbps
+constexpr int kDefaultFramerate = 30;
+}  // namespace
+
+VVencH266Encoder::VVencH266Encoder(const cricket::VideoCodec& codec)
+    : codec_(codec),
+      encoder_(nullptr),
+      config_(nullptr),
+      encoded_image_callback_(nullptr),
+      target_bitrate_bps_(kDefaultTargetBitrate),
+      max_bitrate_bps_(kDefaultMaxBitrate),
+      framerate_fps_(kDefaultFramerate),
+      frames_since_keyframe_(0),
+      initialized_(false) {
+  RTC_LOG(LS_INFO) << "Creating VVencH266Encoder";
+}
+
+VVencH266Encoder::~VVencH266Encoder() {
+  Release();
+}
+
+bool VVencH266Encoder::IsSupported() {
+  // In a real implementation, check if the VVenC library is available
+  // and if the system has the necessary hardware/software support
+  return false;  // Currently not supported as this is a placeholder
+}
+
+int32_t VVencH266Encoder::InitEncode(const VideoCodec* codec_settings,
+                                     const Settings& settings) {
+  if (!codec_settings || codec_settings->codecType != kVideoCodecH266) {
+    return WEBRTC_VIDEO_CODEC_ERR_PARAMETER;
+  }
+
+  if (codec_settings->maxFramerate == 0) {
+    return WEBRTC_VIDEO_CODEC_ERR_PARAMETER;
+  }
+
+  if (codec_settings->width < 1 || codec_settings->height < 1) {
+    return WEBRTC_VIDEO_CODEC_ERR_PARAMETER;
+  }
+
+  codec_settings_ = *codec_settings;
+  encoder_settings_ = settings;
+
+  // In a real implementation:
+  // 1. Initialize the VVenC encoder
+  // 2. Configure the encoder with the provided settings
+  // 3. Allocate necessary resources
+
+  // For this placeholder, we'll just log the initialization
+  RTC_LOG(LS_INFO) << "Initializing H.266 encoder with resolution: "
+                  << codec_settings_.width << "x" << codec_settings_.height
+                  << ", framerate: " << codec_settings_.maxFramerate;
+
+  framerate_fps_ = codec_settings_.maxFramerate;
+  target_bitrate_bps_ = codec_settings_.startBitrate * 1000;
+  max_bitrate_bps_ = codec_settings_.maxBitrate * 1000;
+  frames_since_keyframe_ = 0;
+
+  if (!ConfigureEncoder()) {
+    Release();
+    return WEBRTC_VIDEO_CODEC_ERROR;
+  }
+
+  initialized_ = true;
+  return WEBRTC_VIDEO_CODEC_OK;
+}
+
+bool VVencH266Encoder::ConfigureEncoder() {
+  // In a real implementation:
+  // 1. Create and configure a vvenc_config structure
+  // 2. Set encoding parameters based on codec_settings_
+  // 3. Initialize the encoder with the configuration
+
+  // For this placeholder, we'll just log the configuration
+  RTC_LOG(LS_INFO) << "Configuring H.266 encoder with bitrate: "
+                  << target_bitrate_bps_ << " bps, framerate: "
+                  << framerate_fps_ << " fps";
+
+  return true;  // Placeholder success
+}
+
+void VVencH266Encoder::SetEncoderPreset(vvenc_config* config, 
+                                        VideoCodecMode mode) {
+  // In a real implementation:
+  // Set the encoder preset based on the codec mode (realtime, quality, etc.)
+  
+  // For this placeholder, we'll just log the mode
+  RTC_LOG(LS_INFO) << "Setting H.266 encoder preset for mode: "
+                  << (mode == VideoCodecMode::kRealtimeVideo ? "realtime" : "quality");
+}
+
+int32_t VVencH266Encoder::Release() {
+  if (initialized_) {
+    // In a real implementation:
+    // 1. Clean up the VVenC encoder
+    // 2. Free allocated resources
+
+    RTC_LOG(LS_INFO) << "Releasing H.266 encoder";
+    initialized_ = false;
+  }
+  return WEBRTC_VIDEO_CODEC_OK;
+}
+
+int32_t VVencH266Encoder::RegisterEncodeCompleteCallback(
+    EncodedImageCallback* callback) {
+  encoded_image_callback_ = callback;
+  return WEBRTC_VIDEO_CODEC_OK;
+}
+
+int32_t VVencH266Encoder::SetRates(const RateControlParameters& parameters) {
+  if (!initialized_) {
+    return WEBRTC_VIDEO_CODEC_UNINITIALIZED;
+  }
+
+  if (parameters.framerate_fps <= 0 || parameters.bitrate.get_sum_bps() <= 0) {
+    return WEBRTC_VIDEO_CODEC_ERR_PARAMETER;
+  }
+
+  target_bitrate_bps_ = parameters.bitrate.get_sum_bps();
+  framerate_fps_ = parameters.framerate_fps;
+
+  // In a real implementation:
+  // Update the encoder's bitrate and framerate settings
+
+  RTC_LOG(LS_INFO) << "H.266 encoder rate control updated: "
+                  << target_bitrate_bps_ << " bps, "
+                  << framerate_fps_ << " fps";
+
+  return WEBRTC_VIDEO_CODEC_OK;
+}
+
+int32_t VVencH266Encoder::Encode(
+    const VideoFrame& input_image,
+    const std::vector<VideoFrameType>* frame_types) {
+  if (!initialized_ || !encoded_image_callback_) {
+    return WEBRTC_VIDEO_CODEC_UNINITIALIZED;
+  }
+
+  if (input_image.width() != codec_settings_.width ||
+      input_image.height() != codec_settings_.height) {
+    return WEBRTC_VIDEO_CODEC_ERR_SIZE;
+  }
+
+  bool force_key_frame = false;
+  if (frame_types && !frame_types->empty()) {
+    force_key_frame = (*frame_types)[0] == VideoFrameType::kVideoFrameKey;
+  }
+
+  // In a real implementation:
+  // 1. Convert the input frame to the format expected by VVenC
+  // 2. Set encoding parameters (QP, frame type, etc.)
+  // 3. Call the VVenC encoding function
+  // 4. Process the encoded data and pass it to the callback
+
+  // For this placeholder, we'll just log the encoding request
+  RTC_LOG(LS_INFO) << "Encoding H.266 frame, force key frame: " << force_key_frame
+                  << ", frame timestamp: " << input_image.timestamp();
+
+  frames_since_keyframe_++;
+
+  // Placeholder: In a real implementation, this would be the actual encoded data
+  // For now, we'll just create a dummy EncodedImage
+  EncodedImage encoded_image;
+  encoded_image._encodedWidth = input_image.width();
+  encoded_image._encodedHeight = input_image.height();
+  encoded_image.SetTimestamp(input_image.timestamp());
+  encoded_image.capture_time_ms_ = input_image.render_time_ms();
+  encoded_image._frameType = force_key_frame ? VideoFrameType::kVideoFrameKey 
+                                            : VideoFrameType::kVideoFrameDelta;
+  
+  // Set codec specific info
+  CodecSpecificInfo codec_specific;
+  codec_specific.codecType = kVideoCodecH266;
+
+  // In a real implementation, this would be the callback with actual encoded data
+  // encoded_image_callback_->OnEncodedImage(encoded_image, &codec_specific);
+
+  return WEBRTC_VIDEO_CODEC_OK;
+}
+
+void VVencH266Encoder::EncoderCallback(void* encoder,
+                                      void* param,
+                                      const uint8_t* encoded_data,
+                                      size_t encoded_size,
+                                      bool is_keyframe) {
+  // This would be called by the VVenC library when encoding is complete
+  // In a real implementation, this would process the encoded data and
+  // pass it to the EncodedImageCallback
+}
+
+VideoEncoder::EncoderInfo VVencH266Encoder::GetEncoderInfo() const {
+  EncoderInfo info;
+  info.supports_native_handle = false;
+  info.implementation_name = "VVenC H.266";
+  info.scaling_settings = VideoEncoder::ScalingSettings(kLowH266QpThreshold,
+                                                       kHighH266QpThreshold);
+  info.is_hardware_accelerated = false;
+  info.has_internal_source = false;
+  info.supports_simulcast = false;
+  return info;
+}
+
+}  // namespace webrtc

--- a/modules/video_coding/codecs/h266/vvenc_h266_encoder.h
+++ b/modules/video_coding/codecs/h266/vvenc_h266_encoder.h
@@ -1,0 +1,89 @@
+/*
+ *  Copyright (c) 2025 The WebRTC project authors. All Rights Reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license
+ *  that can be found in the LICENSE file in the root of the source
+ *  tree. An additional intellectual property rights grant can be found
+ *  in the file PATENTS.  All contributing project authors may
+ *  be found in the AUTHORS file in the root of the source tree.
+ */
+
+#ifndef MODULES_VIDEO_CODING_CODECS_H266_VVENC_H266_ENCODER_H_
+#define MODULES_VIDEO_CODING_CODECS_H266_VVENC_H266_ENCODER_H_
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "api/video_codecs/video_encoder.h"
+#include "common_video/h266/h266_common.h"
+#include "modules/video_coding/include/video_codec_interface.h"
+#include "rtc_base/system/rtc_export.h"
+
+// Forward declaration for VVenC library types
+struct vvenc_config;
+struct vvenc_encoder;
+
+namespace webrtc {
+
+// VVenC H.266 encoder implementation
+class RTC_EXPORT VVencH266Encoder : public VideoEncoder {
+ public:
+  explicit VVencH266Encoder(const cricket::VideoCodec& codec);
+  ~VVencH266Encoder() override;
+
+  int32_t InitEncode(const VideoCodec* codec_settings,
+                     const Settings& settings) override;
+  int32_t Release() override;
+
+  int32_t RegisterEncodeCompleteCallback(
+      EncodedImageCallback* callback) override;
+  int32_t SetRates(const RateControlParameters& parameters) override;
+  int32_t Encode(const VideoFrame& input_image,
+                 const std::vector<VideoFrameType>* frame_types) override;
+
+  EncoderInfo GetEncoderInfo() const override;
+
+  static bool IsSupported();
+
+ private:
+  // Configures the encoder with the settings provided by InitEncode
+  bool ConfigureEncoder();
+
+  // Converts from VideoCodecMode to appropriate encoder preset
+  void SetEncoderPreset(vvenc_config* config, VideoCodecMode mode);
+
+  // Callback function for VVenC encoder
+  static void EncoderCallback(void* encoder,
+                              void* param,
+                              const uint8_t* encoded_data,
+                              size_t encoded_size,
+                              bool is_keyframe);
+
+  // Encoder configuration
+  VideoCodec codec_settings_;
+  Settings encoder_settings_;
+  cricket::VideoCodec codec_;
+
+  // VVenC encoder state
+  vvenc_encoder* encoder_;
+  vvenc_config* config_;
+
+  // Encoded image callback
+  EncodedImageCallback* encoded_image_callback_;
+
+  // Rate control state
+  uint32_t target_bitrate_bps_;
+  uint32_t max_bitrate_bps_;
+  uint32_t framerate_fps_;
+
+  // Frame counter for determining when to insert keyframes
+  uint32_t frames_since_keyframe_;
+
+  // Indicates if the encoder is initialized
+  bool initialized_;
+};
+
+}  // namespace webrtc
+
+#endif  // MODULES_VIDEO_CODING_CODECS_H266_VVENC_H266_ENCODER_H_

--- a/sdk/BUILD.gn
+++ b/sdk/BUILD.gn
@@ -732,7 +732,7 @@ if (is_ios || is_mac) {
       ]
 
       defines = []
-      if (enable_libaom) {
+      if (enable_libaom || rtc_use_libaom_av1_encoder) {
         defines += [ "RTC_USE_LIBAOM_AV1_ENCODER" ]
         deps += [ ":libaom_av1_encoder" ]
       }

--- a/webrtc.gni
+++ b/webrtc.gni
@@ -192,6 +192,9 @@ declare_args() {
   # Enable to use H265
   rtc_use_h265 = proprietary_codecs
 
+  # Enable to use H266
+  rtc_use_h266 = proprietary_codecs
+
   # Enable this flag to make webrtc::Mutex be implemented by absl::Mutex.
   rtc_use_absl_mutex = false
 


### PR DESCRIPTION
This PR enables H.266 codec support in SparkRTC by adding the necessary build configuration.

## Changes
- Added `rtc_use_h266` flag in webrtc.gni
- Updated H.266 encoder and decoder flags to use the global flag
- Added H.266 common files to the build when the flag is enabled
- Added H.266 unit tests to the build when the flag is enabled
- Fixed build error by importing H.266 build flags in api/video_codecs/BUILD.gn
- Moved H.266 build flags to a separate .gni file to fix import errors

The H.266 codec implementation files were already present in the codebase, but they needed to be properly enabled through build configuration.