### PR TITLE
Fix H.266 build errors by handling missing dependencies

### DIFF
--- a/api/video_codecs/BUILD.gn
+++ b/api/video_codecs/BUILD.gn
@@ -13,7 +13,7 @@ if (is_android) {
 }
 
 # Import H.266 build flags
-import("../../modules/video_coding/codecs/h266/BUILD.gn")
+import("../../modules/video_coding/codecs/h266/h266_build_flags.gni")
 
 rtc_source_set("scalability_mode") {
   visibility = [ "*" ]

--- a/modules/video_coding/codecs/h266/BUILD.gn
+++ b/modules/video_coding/codecs/h266/BUILD.gn
@@ -7,14 +7,7 @@
 # be found in the AUTHORS file in the root of the source tree.
 
 import("../../../../webrtc.gni")
-
-declare_args() {
-  # Enable H.266 encoder using VVenC
-  rtc_use_vvenc_h266_encoder = rtc_use_h266
-
-  # Enable H.266 decoder using VVdeC
-  rtc_use_vvdec_h266_decoder = rtc_use_h266
-}
+import("h266_build_flags.gni")
 
 rtc_library("vvenc_h266_encoder") {
   visibility = [ "*" ]

--- a/modules/video_coding/codecs/h266/h266_build_flags.gni
+++ b/modules/video_coding/codecs/h266/h266_build_flags.gni
@@ -1,0 +1,17 @@
+# Copyright (c) 2025 The WebRTC project authors. All Rights Reserved.
+#
+# Use of this source code is governed by a BSD-style license
+# that can be found in the LICENSE file in the root of the source
+# tree. An additional intellectual property rights grant can be found
+# in the file PATENTS.  All contributing project authors may
+# be found in the AUTHORS file in the root of the source tree.
+
+import("../../../../webrtc.gni")
+
+declare_args() {
+  # Enable H.266 encoder using VVenC
+  rtc_use_vvenc_h266_encoder = rtc_use_h266
+
+  # Enable H.266 decoder using VVdeC
+  rtc_use_vvdec_h266_decoder = rtc_use_h266
+}


### PR DESCRIPTION
## Problem
The build was failing with the error:
```
ERROR at //modules/video_coding/codecs/h266/BUILD.gn:19:1: Not valid from an import.
rtc_library("vvenc_h266_encoder") {
^----------------------------------
Imports are for defining defaults, variables, and rules. The
appropriate place for this kind of thing is really in a normal
BUILD file.
```

## Solution
The error was occurring because in GN build system, imports are only meant for defining defaults, variables, and rules - not for defining targets like rtc_library.

This change:
1. Extracts the variable declarations (declare_args) from the BUILD.gn file into a new file called h266_build_flags.gni
2. Updates the original BUILD.gn file to import this new .gni file
3. Updates the import in api/video_codecs/BUILD.gn to import the .gni file instead of the BUILD.gn file

This follows the GN convention where:
- .gni files contain variables, templates, and other reusable elements
- BUILD.gn files contain actual target definitions